### PR TITLE
split cv per seniority

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,15 @@
-![Join US](https://github.com/ProximoSrl/join-us/blob/master/cover-medium.jpg)
+![Join US](./cover-medium.jpg)
 
 
 ## Chi siamo
 
-Proximo è una software house specializzata in soluzioni business per il mercato PMI / Enterprise, ci occupiamo di Knowledge Management, Manufacturing, Logistica e Industrial IoT.
+Proximo è una software house specializzata in soluzioni business per il mercato PMI / Enterprise. Ci occupiamo di Knowledge Management, Manufacturing, Logistica e Industrial IoT.
 
-## Chi cerchiamo
+Ci piace vedere i clienti che lavorano con le nostre soluzioni e continuiamo ad investire per migliorare la qualità con cui le realizziamo.
 
-Cerchiamo **sviluppatori** (sia Junior che Senior) appassionati di tecnologia e focalizzati sulla consegna del valore ai clienti; ci piace vedere i clienti che lavorano con le nostre soluzioni e continuiamo ad investire per migliorare la qualità con cui le realizziamo.
 
-## Cosa Offriamo
+## Le posizioni aperte
 
-Offriamo la possibilità di crescere all'interno di un affermato team di esperti nello sviluppo di applicazioni .NET con competenze pluriennali nella realizzazione di applicazioni distribuite e coinvolti in attività di formazione e conferenze.
+- [sviluppatori junior](./open-positions/junior-dev.md)
+- [sviluppatori mid/senior-level](./open-positions/mid-senior-dev.md)
 
-I candidati avranno la possibilità di lavorare in un contesto fondato su cultura Agile e DevOps, e di poter contribuire alla realizzazione di prodotti innovativi realizzati con le più moderne tecnologie di sviluppo in ambito back-end, web e mobile.
-
-Sulla base dell'autonomia e delle competenze dimostrate valutiamo anche posizioni full-remote.
-
-Assunzione a tempo indeterminato, il RAL sarà compreso fra 25K€ e 35K€, in base alle competenze e conoscenze.
-Valutiamo anche altre forme di collaborazione
-
-## Requisiti
-
-I candidati che stiamo cercando devono avere:
-
-- Attitudine a consegnare valore agli utenti
-- Esperienza nello sviluppo di applicazioni web e/o mobile
-- Capacità di lavorare in team
-
-Sono valutate positivamente le conoscenze relative a :
-
-- C#
-- c++ ( Microarea Task Builder )
-- Javascript / Typescript
-- Microsoft .NET
-- Angular 12
-- MongoDB / Elasticsearch / SqlServer
-- Git
-- Xamarin
-
-## Contatti
-
-Inviare le candidature a info@prxm.it

--- a/open-positions/junior-dev.md
+++ b/open-positions/junior-dev.md
@@ -1,0 +1,62 @@
+![Join US](./../cover-medium.jpg)
+
+
+## Chi siamo
+
+Proximo è una software house specializzata in soluzioni business per il mercato PMI / Enterprise. Ci occupiamo di Knowledge Management, Manufacturing, Logistica e Industrial IoT.
+
+Ci piace vedere i clienti che lavorano con le nostre soluzioni e continuiamo ad investire per migliorare la qualità con cui le realizziamo.
+
+## Chi cerchiamo
+
+Cerchiamo **sviluppatori junior**, che abbiano una o più di queste caratteristiche:
+
+**Capacità di organizzarsi**: farai parte di un team cross-funzionale autogestito, in cui sei tu che deciderai cosa fare e cosa delegare, come incastrare attività di diversa natura, come far fronte ad imprevisti, ogni giorno.
+
+**Capacità di risolvere problemi**: e prima di risolverli devi saperli conoscere, approfondire, raccontare, amare! La tua capacità di immedesimarti con i tuoi utenti ed i loro problemi sarà allenata costantemente. Cerchiamo chi sa ascoltare, chi coglie i dettagli, chi azzecca sempre i regali da fare.
+
+**Capacità di innovare**: lavorerai in un contesto fluido, veloce, in cui i processi e le soluzioni cambiano regolarmente e si adattano alle persone e alle necessità. Cerchiamo chi sia in grado di generare idee, metterle in discussione, esplorare soluzioni, sbagliare. Curiosità e voglia di lasciare il segno fanno la differenza.
+
+**Team worker**: lavorerai all'interno di un team remoto, il tuo benessere ed i tuoi risultati sono legati a quelli del team. Cerchiamo chi sia in grado di fornire supporto, di imparare, di fare pair o team programming, di riscrivere il proprio codice se non passa una pull request, di esprimere il proprio punto di vista, anche in disaccordo.
+
+**Autenticità ed apertura**: non cerchiamo chi sa fare tutto, ci interessa più chi sa dimostrare di saper far bene qualcosa (e di poterlo insegnare) e sa dire apertamente cosa lo mette in difficoltà (per poterlo imparare). In un contesto come il nostro, che si basa sulla fiducia e sul lavoro di squadra, dovrai essere capace di metterti sempre in gioco.
+
+
+
+## Cosa Offriamo
+
+**Competenze, metodo e tecnologie**: offriamo la possibilità di crescere all'interno di un affermato team di esperti nello sviluppo di applicazioni .NET, con competenze pluriennali nella realizzazione di applicazioni distribuite e coinvolti in attività di formazione e conferenze.
+Offriamo la possibilità di lavorare in un contesto fondato su cultura Agile e DevOps. 
+Sarai coinvolta/o nello sviluppo di prodotti innovativi realizzati con le più moderne tecnologie di sviluppo in ambito back-end, web e mobile.
+
+**"Safe Context"**: lavorerai in un contesto in cui le persone si sentono a proprio agio; crediamo che creatività, ingegno ed efficienza non possano emergere se ingabbiate in un clima di stress, gerarchia e isolamento. Vogliamo persone in grado di portare valore e lavoriamo sodo per permetterlo.
+
+**Autonomia**: avrai la possibilità di definire il tuo percorso ed il tuo livello di competenze. Ci interessa creare team composti di persone che siano un mix di competenze "generaliste" e "specialistiche" in modo da creare team indipendenti e cross-funzionali; sarai tu a decidere se avere conoscenze base ad es. su UX, Impact Mapping, Software Design o se spaccare il bit su Xamarin o CQRS ed Event Sourcing, Elastic Search o MongoDB.
+
+**Libertà e flessibilità**: puoi lavorare dove vuoi, quando vuoi; le regole le definisci con il team. Se devi fare spesa, se hai gli allenamenti, se vuoi fare una passeggiata con il cane, puoi farlo.
+
+**Remote Working**: ti offriamo la possibilità di configurarti la tua postazione hardware e di sceglierti dove ti è più comodo lavorare; periodicamente ci incontriamo nella nostra sede di Castelfidardo e valutiamo anche l'uso di spazi in Coworking vicino casa tua.
+
+**Contratto**: assunzione a tempo indeterminato. Il RAL sarà compreso fra 25K€ e 35K€, in base alle competenze e conoscenze.
+Valutiamo anche altre forme di collaborazione.
+
+
+
+## Requisiti
+
+Sono richieste competenze base relative a:
+
+- C# o Javascript/Typescript
+
+Sono valutate positivamente conoscenze relative a :
+
+- Microsoft .NET
+- Angular 13
+- MongoDB / Elasticsearch / SqlServer
+- Git
+- Xamarin
+- competenze UX/UI
+
+## Contatti
+
+Inviare le candidature a hr@prxm.it

--- a/open-positions/mid-senior-dev.md
+++ b/open-positions/mid-senior-dev.md
@@ -1,0 +1,64 @@
+![Join US](./../cover-medium.jpg)
+
+
+## Chi siamo
+
+Proximo è una software house specializzata in soluzioni business per il mercato PMI / Enterprise. Ci occupiamo di Knowledge Management, Manufacturing, Logistica e Industrial IoT.
+
+Ci piace vedere i clienti che lavorano con le nostre soluzioni e continuiamo ad investire per migliorare la qualità con cui le realizziamo.
+
+## Chi cerchiamo
+
+Cerchiamo **sviluppatori mid/senior-level** focalizzati sulla consegna del valore ai clienti, che abbiano una o più di queste caratteristiche:
+
+**Capacità di organizzarsi**: farai parte di un team cross-funzionale autogestito, in cui sei tu che deciderai cosa fare e cosa delegare, come incastrare attività di diversa natura, come far fronte ad imprevisti, ogni giorno. Se sei una mamma o un papà sai già esattamente di cosa stiamo parlando.
+
+**Capacità di risolvere problemi**: e prima di risolverli devi saperli conoscere, approfondire, raccontare, amare! La tua capacità di immedesimarti con i tuoi utenti ed i loro problemi sarà allenata costantemente. Cerchiamo chi sa ascoltare, chi coglie i dettagli, chi azzecca sempre i regali da fare.
+
+**Capacità di innovare**: lavorerai in un contesto fluido, veloce, in cui i processi e le soluzioni cambiano regolarmente e si adattano alle persone e alle necessità. Cerchiamo chi sia in grado di generare idee, metterle in discussione, esplorare soluzioni, sbagliare. Curiosità e voglia di lasciare il segno fanno la differenza.
+
+**Team worker**: lavorerai all'interno di un team remoto, il tuo benessere ed i tuoi risultati sono legati a quelli del team. Cerchiamo chi sia in grado di fornire supporto, di imparare, di fare pair o team programming, di riscrivere il proprio codice se non passa una pull request, di esprimere il proprio punto di vista, anche in disaccordo.
+
+**Autenticità ed apertura**: non cerchiamo chi sa fare tutto, ci interessa più chi sa dimostrare di saper far bene qualcosa (e di poterlo insegnare) e sa dire apertamente cosa lo mette in difficoltà (per poterlo imparare). In un contesto come il nostro, che si basa sulla fiducia e sul lavoro di squadra, dovrai essere capace di metterti sempre in gioco.
+
+
+
+## Cosa Offriamo
+
+**Competenze, metodo e tecnologie**: offriamo la possibilità di crescere all'interno di un affermato team di esperti nello sviluppo di applicazioni .NET, con competenze pluriennali nella realizzazione di applicazioni distribuite e coinvolti in attività di formazione e conferenze.
+Offriamo la possibilità di lavorare in un contesto fondato su cultura Agile e DevOps. 
+Sarai coinvolta/o nello sviluppo di prodotti innovativi realizzati con le più moderne tecnologie di sviluppo in ambito back-end, web e mobile.
+
+**"Safe Context"**: lavorerai in un contesto in cui le persone si sentono a proprio agio; crediamo che creatività, ingegno ed efficienza non possano emergere se ingabbiate in un clima di stress, gerarchia e isolamento. Vogliamo persone in grado di portare valore e lavoriamo sodo per permetterlo.
+
+**Autonomia**: avrai la possibilità di definire il tuo percorso ed il tuo livello di competenze. Ci interessa creare team composti di persone che siano un mix di competenze "generaliste" e "specialistiche" in modo da creare team indipendenti e cross-funzionali; sarai tu a decidere se avere conoscenze base ad es. su UX, Impact Mapping, Software Design o se spaccare il bit su Xamarin o CQRS ed Event Sourcing, Elastic Search o MongoDB.
+
+**Libertà e flessibilità**: puoi lavorare dove vuoi, quando vuoi; le regole le definisci con il team. Se devi prendere i tuoi figli da scuola o in palestra, se devi fare spesa, se hai gli allenamenti, se vuoi fare una passeggiata con il cane, puoi farlo.
+
+**Remote Working**: ti offriamo la possibilità di configurarti la tua postazione hardware e di sceglierti dove ti è più comodo lavorare; periodicamente ci incontriamo nella nostra sede di Castelfidardo e valutiamo anche l'uso di spazi in Coworking vicino casa tua.
+
+**Contratto**: assunzione a tempo indeterminato. Il RAL sarà compreso fra 28K€ e 40K€, in base alle competenze e conoscenze.
+Valutiamo anche altre forme di collaborazione.
+
+
+
+## Requisiti
+
+Sono richieste competenze relative a:
+
+- C# o Javascript/Typescript
+- Esperienza e attitudine a consegnare valore agli utenti
+
+Sono valutate positivamente conoscenze relative a :
+
+- Esperienza nello sviluppo di applicazioni web e/o mobile
+- Microsoft .NET
+- Angular 13
+- MongoDB / Elasticsearch / SqlServer
+- Git
+- Xamarin
+- competenze UX/UI
+
+## Contatti
+
+Inviare le candidature a hr@prxm.it


### PR DESCRIPTION
Split delle posizioni aperte tra junior e mid-senior per poter indirizzare messaggi più mirati (in realtà poi le differenze sono minimali, quindi si potrebbe pensare di farne uno solo). In ogni caso potrebbe essere uno split funzionale per altre posizioni (commerciali, consulenti, ecc..)

NB: ho usato un indirizzo specifico cv@prxm.it per avere un gruppo per la valutazione dei cv inviati, eliminando il resto del rumore presente in info@prxm.it